### PR TITLE
Fix link to VSHN Login documentation

### DIFF
--- a/theme/login/messages/messages_en.properties
+++ b/theme/login/messages/messages_en.properties
@@ -1,2 +1,2 @@
 loginAccountTitle=Sign in with VSHN Account or external provider.
-identity-provider-login-label=First time here? Just login with an external provider of your choice. For more details see https://kb.vshn.ch/kb/vshn-login.html.
+identity-provider-login-label=First time here? Just login with an external provider of your choice. See https://kb.vshn.ch/kb/vshn-login.html for more details.

--- a/theme/login/messages/messages_en.properties
+++ b/theme/login/messages/messages_en.properties
@@ -1,2 +1,2 @@
 loginAccountTitle=Sign in with VSHN Account or external provider.
-identity-provider-login-label=First time here? Just login with an external provider of your choice. For more details see https://kb.vshn.net/kb/vshn-login.
+identity-provider-login-label=First time here? Just login with an external provider of your choice. For more details see https://kb.vshn.ch/kb/vshn-login.html.

--- a/theme/login/resources/js/script.js
+++ b/theme/login/resources/js/script.js
@@ -140,6 +140,7 @@ function reset() {
     TweenMax.to('.vshnEye', 1, {x: 0, y: 0, scaleY: 1, scaleX: 1, ease: Expo.easeOut})
 }
 function replaceLinkWithHref(element) {
+    // TODO Exclude interpunctuation at the end of a URL.
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
     const text = element.innerText;
     element.innerHTML = text.replace(urlRegex, '<a href="$&">$&</a>');


### PR DESCRIPTION
## Summary

Prevent the punctuation from being pulled into the link. Tweaking the regex was outside my time budget. Fixed by doing a reword.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
