### PR TITLE
Update CSS for login theme and Keycloak image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,5 @@ services:
       - --spi-theme-static-max-age=-1
       - --spi-theme-cache-themes=false
       - --spi-theme-cache-templates=false
-      - --spi-theme-login-theme=vshn
     volumes:
       - ./theme:/opt/keycloak/themes/vshn:ro

--- a/theme/login/resources/css/styles.css
+++ b/theme/login/resources/css/styles.css
@@ -157,6 +157,11 @@
     flex-direction: column;
     gap: 1rem;
     width: 100%;
+    list-style-type: none;
+}
+
+.social-account-list a{
+    width: 100%;
 }
 
 #social-google {


### PR DESCRIPTION
## Summary

Adjusted the style for the social account list in the login theme, removing bullet points for list items and making sure that anchor elements span 100% width. Additionally, updated Keycloak docker image from version 21.0 to 22.0 for the latest features and security patches in the docker-compose.yml file.

Closes https://github.com/vshn/keycloak-theme/issues/44

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
