### PR TITLE
Update Theme for Keycloak 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ VSHN Keycloak IDP Theme
 
 ## Local Development
 
-`docker compose up` to start a local Keycloak with the VSHN theme.
+1. `docker compose up` to start a local Keycloak with the VSHN theme.
+2. Open the Keycloak admin console at [http://localhost:8080](http://localhost:8080) to see the login view
+3. Login with the user `admin` and password `admin` to see the admin console
 
 ### Configure the Themes
 
@@ -17,6 +19,10 @@ If the theme is not available in the dropdown, it usually means that it is not v
 
 You can export the realm via the admin console.
 This export does not include secrets, but since we only have one admin user, it is not a problem.
+
+### Upgrade to new Keycloak version
+
+1. Update the `docker-compose.yml` file to the new Keycloak version
 
 ## Deploy to Your Instance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:25.0.6
+    image: quay.io/keycloak/keycloak:26.2.4
     ports:
       - "8080:8080"
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     entrypoint: /opt/entrypoint.sh
     volumes:
       - ./theme:/opt/keycloak/themes/vshn:ro

--- a/theme/account/theme.properties
+++ b/theme/account/theme.properties
@@ -2,3 +2,4 @@ parent=keycloak.v3
 favIcon=/public/favicon.ico
 logo=/public/logo.svg
 styles=public/layout.css
+darkMode=false


### PR DESCRIPTION
## Summary

Make the VSHN theme compatible with Keycloak 26.2.4

Closes https://github.com/vshn/keycloak-theme/issues/56

### Disable dark mode

The dark mode for the account theme is now disabled, as the current theme customization doesn't support dark mode.
Supporting dark mode means changing/switching many CSS variables, which is fairly time-consuming.

It is based on the parent theme `keycloak.v3`, this is the latest version and no upgrade needed.

### Login Theme

The theme for the login screen has completely custom styling, and has no dark mode yet. 
It is based on the parent theme `base`, which is a minimalistic theme without styling. Therefore, no theme upgrade (e.g. to `keycloak.v3`) is needed.

### Local Development

Updated the Keycloak version for local Docker image, and added some more details to the readme.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
