### PR TITLE
📱 Login Pages Mobile Friendly

### DIFF
--- a/theme/account/resources/public/layout.css
+++ b/theme/account/resources/public/layout.css
@@ -214,14 +214,6 @@
 }
 
 
-.brand {
-    height: 35px;
-}
-
-.delete-button {
-    width: 150px;
-    height: 50px;
-}
 
 .pf-v5-c-menu-toggle {
     --pf-v5-c-menu-toggle--after--BorderBottomWidth: 0;
@@ -234,11 +226,6 @@
     --pf-v5-c-menu-toggle--before--BorderRightWidth: 0;
 }
 
-@media (max-width: 320px) {
-    .delete-button {
-        width: 120px;
-        height: 50px;
-    }
 
 }
 

--- a/theme/account/resources/public/layout.css
+++ b/theme/account/resources/public/layout.css
@@ -233,6 +233,21 @@
   }
 }
 
+@media (max-width: 992px) {
+    [data-page-id="account"] header.pf-v5-c-masthead {
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    [data-page-id="account"] header .pf-v5-c-toolbar__content-section {
+      justify-content: flex-end;
+    }
+
+    [data-page-id="account"] header  .pf-v5-c-toolbar__item.pf-m-align-right {
+      margin-inline-start: unset;
+    }
+}
+
 @font-face {
     font-family: "Montserrat";
     font-style: normal;

--- a/theme/account/resources/public/layout.css
+++ b/theme/account/resources/public/layout.css
@@ -226,7 +226,11 @@
     --pf-v5-c-menu-toggle--before--BorderRightWidth: 0;
 }
 
-
+@media (max-width: 768px) {
+  div[data-testrole="created-at"].pf-v5-c-data-list__cell {
+    order: unset;
+    padding-block-end: 0.5rem;
+  }
 }
 
 @font-face {

--- a/theme/login/resources/css/styles.css
+++ b/theme/login/resources/css/styles.css
@@ -25,10 +25,11 @@
 .logo-wrapper {
     margin-top: 1.5rem;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
-    gap: 3rem;
-    height: 3rem;
+    column-gap: 3rem;
+    row-gap: 1rem;
     width: 100%;
 }
 
@@ -116,6 +117,13 @@
     max-width: 950px;
 }
 
+@media (max-width: 850px) {
+    .splash-container {
+        margin: 0;
+        padding: 0;
+    }
+}
+
 #kc-totp-settings {
     padding-left: 20px;
 }
@@ -177,8 +185,8 @@ body[data-page-id="login-login"] .form-settings {
 }
 
 body[data-page-id="login-login"] #kc-content-wrapper {
-    display: grid;
-    grid-auto-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
 }
 
 body[data-page-id="login-register"] #kc-content-wrapper,
@@ -191,15 +199,13 @@ body[data-page-id="login-login-update-password"] #kc-content-wrapper {
 }
 
 body[data-page-id="login-login"] #kc-form {
-    grid-row:  2 / span 1;
-    grid-column: 1 / span 1;
-    padding: 3.75rem 3.75rem 0 3.75rem;
+    order: 1;
 }
 
 body[data-page-id="login-login"] #kc-info {
-    grid-row:  3 / span 1;
-    grid-column: 1 / span 1;
-    padding: 0 3.75rem 3.75rem 3.75rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    order: 2;
 }
 
 #kc-registration a {
@@ -207,17 +213,45 @@ body[data-page-id="login-login"] #kc-info {
 }
 
 body[data-page-id="login-login"] #kc-social-providers {
-    grid-row:  2 / span 2;
-    grid-column: 2 / span 1;
-    margin-top: 2rem;
+    margin-top: 1rem;
     margin-bottom: 2rem;
-    padding-left: 3.75rem;
-    padding-right: 3.75rem;
-    border-left: 1px solid rgba(0, 0, 0, 0.1);;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: none;
+    order: 3;
 }
 
-body[data-page-id="login-login"] #kc-content-wrapper .alert {
+/** Grid layout on main login form for larger screens */
+@media (min-width: 850px) {
+  body[data-page-id="login-login"] #kc-content-wrapper {
+    display: grid;
+    grid-auto-columns: 1fr 1fr;
+  }
+
+  body[data-page-id="login-login"] #kc-form {
+    grid-row:  2 / span 1;
+    grid-column: 1 / span 1;
+    padding: 3.75rem 3.75rem 0 3.75rem;
+  }
+
+  body[data-page-id="login-login"] #kc-info {
+    grid-row:  3 / span 1;
+    grid-column: 1 / span 1;
+    padding: 0 3.75rem 3.75rem 3.75rem;
+  }
+
+  body[data-page-id="login-login"] #kc-social-providers {
+    grid-row:  2 / span 2;
+    grid-column: 2 / span 1;
+    border-left: 1px solid rgba(0, 0, 0, 0.1);
+    border-top: 0;
+    padding-left: 3.75rem;
+    padding-right: 3.75rem;
+  }
+
+  body[data-page-id="login-login"] #kc-content-wrapper .alert {
     grid-column: 1 / span 2;
+  }
 }
 
 #kc-social-providers hr {
@@ -296,7 +330,7 @@ header.banner .col-md-10 {
 ol#kc-totp-settings {
     counter-reset: otp-steps-counter;
     list-style: none;
-    padding-left: 3.5rem;
+    padding-left: 1.5rem;
     margin-bottom: 0;
 }
 
@@ -335,10 +369,20 @@ ul#kc-totp-supported-apps li {
 }
 
 #kc-totp-settings-form {
-    margin-left: 3.5rem;
+    margin-left: 1.5rem;
     padding-left: 2.5rem;
     max-width: 40rem;
     border-left: 1px solid #d5d8de;
+}
+
+@media (min-width: 850px) {
+  ol#kc-totp-settings {
+    padding-left: 3.5rem;
+  }
+
+  #kc-totp-settings-form {
+    margin-left: 3.5rem;
+  }
 }
 
 body[data-page-id="login-login-verify-email"] #kc-content-wrapper .alert {

--- a/theme/login/theme.properties
+++ b/theme/login/theme.properties
@@ -1,7 +1,7 @@
 parent=base
 import=common/keycloak
 styles=css/beagle.css css/styles.css css/material-design-iconic-font.min.css
-scripts=js/dark-mode.js js/script.js
+scripts=js/script.js
 
 meta=viewport==width=device-width,initial-scale=1
 

--- a/theme/login/theme.properties
+++ b/theme/login/theme.properties
@@ -1,7 +1,7 @@
 parent=base
 import=common/keycloak
 styles=css/beagle.css css/styles.css css/material-design-iconic-font.min.css
-scripts=js/script.js
+scripts=js/dark-mode.js js/script.js
 
 meta=viewport==width=device-width,initial-scale=1
 


### PR DESCRIPTION
## Summary

Makes login pages mobile friendly. That includes main login form, password reset, OTP setup, registration form. 

Also some small changes on the account pages so they look better on mobile:
 - Arrange items in header better
 - Move action button to the end in the password / OTP list

<details><summary>Screenshots</summary>

<img width="338" height="734" alt="image" src="https://github.com/user-attachments/assets/150ece5d-bce3-4e8e-8003-9f817b3ca4ed" />. 


<img width="338" height="734" alt="image" src="https://github.com/user-attachments/assets/d6cb3bed-1b8e-4869-9e30-de7559434bac" />. 


<img width="338" height="734" alt="image" src="https://github.com/user-attachments/assets/659959fa-8420-4522-96ed-36ff37d3fc7a" />. 


<img width="434" height="638" alt="image" src="https://github.com/user-attachments/assets/6965b1af-8412-44e2-b8c3-5e6613a05bd2" />

</details>

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
